### PR TITLE
Loop through array with for-each, not for-in 

### DIFF
--- a/demo/jquery.PrintArea.js
+++ b/demo/jquery.PrintArea.js
@@ -123,8 +123,8 @@
         elements.each(function() {
             var ele = getFormData( $(this) );
 
-            var attributes = ""
-            for ( var x in attrs )
+            var attributes = "";
+            for ( var x = 0; x < attrs.length; x++ )
             {
                 var eleAttr = $(ele).attr( attrs[x] );
                 if ( eleAttr ) attributes += (attributes.length > 0 ? " ":"") + attrs[x] + "='" + eleAttr + "'";


### PR DESCRIPTION
Modern browsers don't mind this, but IE8 iterates over Array.prototype properties as well as array elements, causing it to break there.
