### PR TITLE
Update jquery.PrintArea.js (callback fix)

### DIFF
--- a/demo/jquery.PrintArea.js
+++ b/demo/jquery.PrintArea.js
@@ -73,11 +73,13 @@
             writeDoc.write( docType() + "<html>" + getHead() + getBody( $(this) ) + "</html>" );
             writeDoc.close();
 
-            printWindow.focus();
-            printWindow.print();
-
-            if ( settings.mode == modes.popup && settings.popClose )
-                printWindow.close();
+            $(writeDoc).ready(function () {
+                printWindow.focus();
+                printWindow.print();
+    
+                if ( settings.mode == modes.popup && settings.popClose )
+                    printWindow.close();
+            });
         }
 
     function docType()


### PR DESCRIPTION
Delay printing popup document until "ready"--fixes issue in chrome the document is print before the css styling is applied correctly.
