### PR TITLE
Chrome not rendering and Printing in Popup correctly

### DIFF
--- a/demo/jquery.PrintArea.js
+++ b/demo/jquery.PrintArea.js
@@ -73,11 +73,16 @@
             writeDoc.write( docType() + "<html>" + getHead() + getBody( $(this) ) + "</html>" );
             writeDoc.close();
 
-            printWindow.focus();
-            printWindow.print();
+            $(writeDoc).ready(function () {
+                printWindow.focus();
+                printWindow.print();
+    
+                if (settings.mode == modes.popup && settings.popClose) {
+                    setTimeout(function () { printWindow.close(); }, 2000);
+                }
+    
+            });
 
-            if ( settings.mode == modes.popup && settings.popClose )
-                printWindow.close();
         }
 
     function docType()


### PR DESCRIPTION
CSS is not applied correctly in Chrome popup before the document "print" method is called.  A delay is required to format HTML before print event is fired.
