### PR TITLE
return promise

### DIFF
--- a/js/jquery.printarea.js
+++ b/js/jquery.printarea.js
@@ -46,6 +46,7 @@
 
     $.fn.printArea = function( options )
     {
+        var deferred = new $.Deferred();
         $.extend( settings, defaults, options );
 
         counter++;
@@ -60,7 +61,9 @@
 
         PrintArea.write( PrintAreaWindow.doc, $printSource );
 
-        setTimeout( function () { PrintArea.print( PrintAreaWindow ); }, 1000 );
+        setTimeout( function () { PrintArea.print( PrintAreaWindow ); deferred.resolve() }, 1000 );
+
+        return deferred.promise();
     };
 
     var PrintArea = {


### PR DESCRIPTION
This allows you to do things like:

``` js
$('.print-element').printArea().then(function() {
  //run after print dialog closed
});
```

Because we are using `setTimeout`, the code becomes asynchronous, even if `.print` is blocking.
This shouldn't cause any backward compatibility issues.
