### PR TITLE
Print Preview is blank if there are more than 30 pages, so wait for d…

### DIFF
--- a/js/jquery.printarea.js
+++ b/js/jquery.printarea.js
@@ -60,7 +60,15 @@
 
         PrintArea.write( PrintAreaWindow.doc, $printSource );
 
-        setTimeout( function () { PrintArea.print( PrintAreaWindow ); }, 1000 );
+        printFunc = function(PrintAreaWindow){
+                      if(PrintAreaWindow.doc.readyState === 'complete'){
+                        PrintArea.print( PrintAreaWindow );
+                      }
+                      else{
+                        setTimeout( function () { printFunc( PrintAreaWindow ); }, 1000 );
+                      }
+                    }
+        printFunc(PrintAreaWindow);
     };
 
     var PrintArea = {


### PR DESCRIPTION
Print Preview is blank if there are more than 30 pages, so wait for document ready state complete. 1 sec is not enough for document finish writing content and print is invoked while in `interactive` state causing blank page.